### PR TITLE
parse the event description from connpass

### DIFF
--- a/event/connpass.go
+++ b/event/connpass.go
@@ -45,7 +45,7 @@ func (self *Connpass) Get(baseurl, keyword, nickname string, places []string) ([
 					Url:         e.Event_url,
 					Summary:     e.Catch,
 					Place:       e.Address + "\n" + e.Place,
-					Description: e.Description,
+					Description: parse(e.Description),
 				}
 				if event.Summary == "" {
 					event.Summary = trim(event.Description)


### PR DESCRIPTION
This PR removes HTML tags from the event description of connpass api.
